### PR TITLE
Fix to remove deprecated call to displayNumbers

### DIFF
--- a/Sources/ABSteppedProgessBar.swift
+++ b/Sources/ABSteppedProgessBar.swift
@@ -252,7 +252,7 @@ import CoreGraphics
       progressLayer.path = progressPath.CGPath
       progressLayer.fillColor = selectedBackgoundColor.CGColor
       
-      if(self.displayNumbers) {
+      if(self.displayStepText) {
         self.renderTextIndexes()
       }
     }


### PR DESCRIPTION
As displayNumbers is deprecated as of v0.0.5 in favor of displayStepText, logic below should use displayStepText.
